### PR TITLE
Can't run as a jar.

### DIFF
--- a/bin/main.rb
+++ b/bin/main.rb
@@ -51,4 +51,13 @@ cfg.title = "LunarLander"
 cfg.useGL20 = true
 cfg.width = 640
 cfg.height = 480
-LwjglApplication.new(MyGame.new, cfg)
+
+game = MyGame.new
+
+LwjglApplication.new(game, cfg)
+
+# Prevent application from exiting while running as a jar
+while game.is_running
+  sleep(1)
+end
+

--- a/lib/ruby/my_game.rb
+++ b/lib/ruby/my_game.rb
@@ -13,9 +13,13 @@ require 'startup_state'
 class MyGame < Game
   include ApplicationListener
 
-  attr_reader :game_clock
+  attr_reader :game_clock, :is_running
 
   GAME_CLOCK_MULTIPLIER=1
+
+  def initialize
+    @is_running = true
+  end
 
   def create
     @game_clock = Time.utc(2000,"jan",1,20,15,1)
@@ -28,4 +32,7 @@ class MyGame < Game
     @game_clock += (seconds)
   end
 
+  def dispose
+    @is_running = false
+  end
 end


### PR DESCRIPTION
I'm not sure where the issue lies, if it's even part of your setup. But if I build the jar and try to run it, it exists without ever showing a window, or anything noteworthy (like exceptions) to the console. The last line about `AL lib` seems to happen whenever you kill a libgdx app unexpectedly, I get the same message when I break stuff in my own experimenting.

```
Clurican ~/Dropbox/Dev/ecs_game [git: recf_libgdx]
∴ rake jar
rm -f ecs_game.jar
Creating ecs_game.jar
rm -f bin/main.class lib/ruby/components/component.class lib/ruby/components/engine.class lib/ruby/components/fuel.class lib/ruby/components/gravity_sensitive.class lib/ruby/components/landable.class lib/ruby/components/motion.class lib/ruby/components/pad.class lib/ruby/components/player_input.class lib/ruby/components/polygon_collidable.class lib/ruby/components/renderable.class lib/ruby/components/spatial_state.class lib/ruby/entity_manager.class lib/ruby/my_game.class lib/ruby/playing_state.class lib/ruby/startup_state.class lib/ruby/systems/asteroid_system.class lib/ruby/systems/collision_system.class lib/ruby/systems/engine_system.class lib/ruby/systems/input_system.class lib/ruby/systems/landing_system.class lib/ruby/systems/physics.class lib/ruby/systems/rendering_system.class lib/ruby/systems/spatial_system.class lib/ruby/systems/system.class

Clurican ~/Dropbox/Dev/ecs_game [git: recf_libgdx]
∴ java -jar ./ecs_game.jar
I, [2012-12-15T23:48:06.116000 #58041]  INFO -- : Uses The Ruby Entity-Component Framework, Copyright 2012 Prylis Inc.
I, [2012-12-15T23:48:06.128000 #58041]  INFO -- : See https://github.com/cpowell/ruby-entity-component-framework
I, [2012-12-15T23:48:06.128000 #58041]  INFO -- : Please preserve this notice in your own games. Thanks for playing fair!
AL lib: ReleaseALC: 1 device not closed
```

[Edit] Some extra info. I'm using rvm and here's my java and jruby versions:

```
Clurican ~/Dropbox/Dev/ecs_game [git: recf_libgdx]
∴ java -version
java version "1.6.0_37"
Java(TM) SE Runtime Environment (build 1.6.0_37-b06-434-11M3909)
Java HotSpot(TM) 64-Bit Server VM (build 20.12-b01-434, mixed mode)

Clurican ~/Dropbox/Dev/ecs_game [git: recf_libgdx]
∴ jruby -v
jruby 1.7.0 (1.9.3p203) 2012-10-22 ff1ebbe on Java HotSpot(TM) 64-Bit Server VM 1.6.0_37-b06-434-11M3909 [darwin-x86_64]
```
