### PR TITLE
Fix relative root for .jar

### DIFF
--- a/bin/main.rb
+++ b/bin/main.rb
@@ -14,7 +14,7 @@ $:.push File.expand_path('../../lib/', __FILE__)
 $:.push File.expand_path('../../lib/ruby/', __FILE__)
 
 # Need a different root when inside the jar, luckily $0 is "<script>" in that case
-RELATIVE_ROOT = $0['<'] ? 'recf/' : ''
+RELATIVE_ROOT = $0['<'] ? 'ruby-entity-component-framework/' : ''
 
 require 'java'
 require "gdx-backend-lwjgl-natives.jar"


### PR DESCRIPTION
Fixed this error when running rake jar

Exception in thread "LWJGL Application" com.badlogic.gdx.utils.GdxRuntimeExcepti
on: com.badlogic.gdx.utils.GdxRuntimeException: Couldn't load file: recf/res/ima
ges/bg.png
        at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplicati
on.java:111)
Caused by: com.badlogic.gdx.utils.GdxRuntimeException: Couldn't load file: recf/
res/images/bg.png
        at com.badlogic.gdx.graphics.Pixmap.<init>(Pixmap.java:140)
        at com.badlogic.gdx.graphics.glutils.FileTextureData.prepare(FileTexture
Data.java:64)
        at com.badlogic.gdx.graphics.Texture.load(Texture.java:175)
        at com.badlogic.gdx.graphics.Texture.create(Texture.java:159)
        at com.badlogic.gdx.graphics.Texture.<init>(Texture.java:133)
        at com.badlogic.gdx.graphics.Texture.<init>(Texture.java:122)
