### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ shortcomings of OOP and streamlines game creation and maintenance.
 
 The RECF has been documented in a series of blog posts by the author:
 
-###Entity-Component game programming using JRuby and libGDX
+### Entity-Component game programming using JRuby and libGDX
 
 * [Part 1 - introduction and nomenclature](http://cbpowell.wordpress.com/2012/10/30/entity-component-game-programming-using-jruby-and-libgdx-part-1/)
 * [Part 2 - entities and the entity manager](http://wp.me/pFIOD-f0)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
